### PR TITLE
Develop/v0.1.24

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -17,7 +17,7 @@ permissions:
 
 jobs:
   auto-release:
-    if: github.event_name == 'push' || (github.event.pull_request.merged == true)
+    if: (github.event_name == 'push' || (github.event.pull_request.merged == true)) && github.repository == 'taxi-tabby/express.js-kusto'
     runs-on: ubuntu-latest
     
     steps:

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -51,11 +51,11 @@ jobs:
         # 현재 버전 사용 (증가시키지 않음)
         PACKAGE_VERSION="${{ steps.version_info.outputs.package_version }}"
         
-        # 현재 날짜와 시간을 버전에 추가
+        # 현재 날짜와 시간 (릴리즈 노트용)
         TIMESTAMP=$(date +"%Y.%m.%d-%H%M")
         
-        # 태그 생성 (framework-v{package_version}-{timestamp})
-        TAG_NAME="framework-v${PACKAGE_VERSION}-${TIMESTAMP}"
+        # 태그 생성 (framework-v{package_version})
+        TAG_NAME="framework-v${PACKAGE_VERSION}"
         
         echo "tag_name=${TAG_NAME}" >> $GITHUB_OUTPUT
         echo "package_version=${PACKAGE_VERSION}" >> $GITHUB_OUTPUT


### PR DESCRIPTION
This pull request updates the `.github/workflows/auto-release.yml` file to refine the release workflow by adding a repository check to the release condition and simplifying the tag generation process.

### Workflow condition updates:
* Updated the `if` condition in the `auto-release` job to include a check ensuring the workflow only runs for the `taxi-tabby/express.js-kusto` repository.

### Tag generation simplification:
* Modified the tag generation logic to exclude the timestamp, resulting in tags formatted as `framework-v{package_version}` instead of `framework-v{package_version}-{timestamp}`.