### PR TITLE
fix(ci): auto-release 빈 커밋-타입 섹션 버그 수정 (v0.2.0 릴리스 누락 복구)

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -162,10 +162,16 @@ jobs:
         fi
 
         # Emit a "### Title" section for a commit-type pattern, only if non-empty.
+        # NOTE: must end in a command that returns 0 — under `bash -e`, a function whose
+        # last command is `[ -n "$body" ] && printf ...` returns 1 when the section is
+        # empty, and a standalone `emit ...` call would then abort the whole step
+        # (e.g. a release range with no `perf` commits). Use `if` so emit always returns 0.
         emit() {
           local body
           body=$(printf "%s\n" "$COMMITS" | grep -iE "$1" || true)
-          [ -n "$body" ] && printf "### %s\n%s\n\n" "$2" "$body"
+          if [ -n "$body" ]; then
+            printf "### %s\n%s\n\n" "$2" "$body"
+          fi
         }
 
         {


### PR DESCRIPTION
## 문제

PR #38(v0.2.0) 머지 시 **Auto Release Framework** 워크플로가 실행됐으나 **"Generate release notes" 스텝에서 실패**(run [#27883329368](https://github.com/taxi-tabby/express.js-kusto/actions/runs/27883329368))해 `framework-v0.2.0` 릴리스가 생성되지 않았다.

## 원인

`bash -e` 하에서 `emit()` 의 마지막 명령이 `[ -n "$body" ] && printf ...` 인데, 섹션이 비면(예: 릴리스 범위에 `perf` 커밋이 없을 때) 함수가 1을 반환하고, standalone `emit ...` 호출이 스텝 전체를 중단시킨다. v0.2.0 범위에는 `perf` 커밋이 없어 `emit "^- perf"` 에서 죽었다. (v0.1.47 은 이 `emit` 그룹화가 추가되기 *이전* 워크플로로 릴리스되어 영향 없음.)

guard·패키지/맵 생성·기여자 스텝은 모두 통과했고, 노트 스텝만 실패.

## 수정

`emit()` 을 `if` 기반으로 바꿔 **항상 0을 반환**하도록 함. (standalone `[ -n ] && ...` 는 `bash -e` 보호 대상이지만, 함수의 반환값은 보호되지 않는 차이.)

## 복구

이 핫픽스를 main 에 머지하면 auto-release 가 **고쳐진 워크플로로 재실행**되고, guard 가 `framework-v0.2.0` 부재를 확인 → v0.2.0 릴리스를 CI 동등성으로 생성한다(업데이트 패키지 + 파일맵 자산 포함).
