### PR TITLE
fix(di): injectable/middleware getter 캐스트 정정 (as unknown as) — TS2352

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "kusto-server",
-    "version": "0.2.7",
+    "version": "0.2.8",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "kusto-server",
-            "version": "0.2.7",
+            "version": "0.2.8",
             "license": "ISC",
             "dependencies": {
                 "@expressjs-kusto/react": "^0.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "kusto-server",
-    "version": "0.2.7",
+    "version": "0.2.8",
     "description": "Express based custom server for simple backend service",
     "main": "index.js",
     "bin": {


### PR DESCRIPTION
## 요약
`DependencyInjector` 의 `getInjectedModules()` / `getInjectedMiddlewares()` 가 내부 저장소 `Record<string, unknown>` 를 생성된 `Injectable` / `Middleware` 인터페이스로 **직접 캐스팅**하고 있었다. 인덱스 시그니처 없는 interface 와 `Record<string, unknown>` 사이는 양방향 어느 쪽으로도 대입 불가라, 소비 프로젝트가 첫 모듈/미들웨어를 추가해 인터페이스에 멤버가 생기는 순간 **TS2352**(`neither type sufficiently overlaps`)로 타입체크가 깨졌다.

## 근본 원인
- `dependencyInjector.ts:171` `return this.modules as Injectable;`
- `dependencyInjector.ts:182` `return this.middlewares as Middleware;`
- 프레임워크 자신의 `src/app/injectable/` 이 비어 있어 두 인터페이스가 `{}` 였던 탓에 그동안 **잠복**해 있던 결함. 소비 프로젝트(`__familly-vote-web`)가 첫 미들웨어를 추가하면서 표면화됨.

## 수정
레포에 이미 쓰이는 표준 관용구인 이중 캐스트(`as unknown as`)로 교정 (컴파일러가 제안하던 형태):
- `return this.modules as unknown as Injectable;`
- `return this.middlewares as unknown as Middleware;`

`getModule` / `getMiddleware`(`:189`/`:196`)는 `unknown` 인덱싱 후 캐스트라 영향 없음. 형제 매니저(`repositoryManager`/`prismaManager`/`kustoManager`) 전수 확인 결과 같은 패턴 없음. 내부 캐스트만 변경되어 export·의존 방향 불변 → `AGENTS.md` 갱신 불필요.

## 검증
- 소비 프로젝트 실패를 합성 재현: 직접 캐스트에서 동일한 TS2352, 이중 캐스트는 무에러.
- `npm run typecheck` (`tsc -p tsconfig.webpack.json --noEmit`) → **OK**, 프레임워크 빌드 무회귀.
